### PR TITLE
Fix bug where deep matcher expects a map passed into the matches function

### DIFF
--- a/lib/mockito.dart
+++ b/lib/mockito.dart
@@ -148,7 +148,7 @@ class InvocationMatcher {
 
   bool isMatchingArg(roleArg, actArg) {
     if(roleArg is _ArgMatcher){
-      return roleArg._matcher==null || roleArg._matcher.matches(actArg, null);
+      return roleArg._matcher==null || roleArg._matcher.matches(actArg, {});
 //    } else if(roleArg is Mock){
 //      return identical(roleArg, actArg);
     }else{  

--- a/test/mockitoSpec.dart
+++ b/test/mockitoSpec.dart
@@ -142,6 +142,11 @@ main(){
       when(mock.methodWithoutArgs()).thenReturn("B");
       expect(mock.methodWithoutArgs(), equals("B"));
     });  
+    test("should mock method with calculated result", (){
+      when(mock.methodWithNormalArgs(argThat(equals(43)))).thenReturn("43");
+      when(mock.methodWithNormalArgs(argThat(equals(42)))).thenReturn("42");
+      expect(mock.methodWithNormalArgs(43), equals("43"));
+    });
     
   });
 


### PR DESCRIPTION
Get around a bug in core matchers where matchers expect a non-null map value for deep matcher. See: https://github.com/dart-lang/matcher/issues/1