### PR TITLE
Added an explicit check of named arguments to InvocationMatcher to en…

### DIFF
--- a/lib/mockito.dart
+++ b/lib/mockito.dart
@@ -149,6 +149,12 @@ class InvocationMatcher {
       }
       index++;
     }
+    Set roleKeys = roleInvocation.namedArguments.keys.toSet();
+    Set actKeys = invocation.namedArguments.keys.toSet();
+    if (roleKeys.difference(actKeys).isNotEmpty ||
+        actKeys.difference(roleKeys).isNotEmpty) {
+      return false;
+    }
     for (var roleKey in roleInvocation.namedArguments.keys) {
       var roleArg = roleInvocation.namedArguments[roleKey];
       var actArg = invocation.namedArguments[roleKey];
@@ -161,7 +167,7 @@ class InvocationMatcher {
 
   bool isMatchingArg(roleArg, actArg) {
     if (roleArg is _ArgMatcher) {
-      return roleArg._matcher == null || roleArg._matcher.matches(actArg, {});
+      return roleArg._matcher.matches(actArg, {});
 //    } else if(roleArg is Mock){
 //      return identical(roleArg, actArg);
     } else {
@@ -280,8 +286,8 @@ class _ArgMatcher {
   _ArgMatcher(this._matcher, this._capture);
 }
 
-get any => new _ArgMatcher(null, false);
-get captureAny => new _ArgMatcher(null, true);
+get any => new _ArgMatcher(anything, false);
+get captureAny => new _ArgMatcher(anything, true);
 captureThat(Matcher matcher) => new _ArgMatcher(matcher, true);
 argThat(Matcher matcher) => new _ArgMatcher(matcher, false);
 

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -6,6 +6,7 @@ class RealClass {
   String methodWithNormalArgs(int x) => "Real";
   String methodWithPositionalArgs(int x, [int y]) => "Real";
   String methodWithNamedArgs(int x, {int y}) => "Real";
+  String methodWithTwoNamedArgs(int x, {int y, int z}) => "Real";
   String get getter => "Real";
   void set setter(String arg) {
     throw new StateError("I must be mocked");
@@ -111,6 +112,17 @@ void main() {
       when(mock.methodWithNormalArgs(any)).thenReturn("A lot!");
       expect(mock.methodWithNormalArgs(100), equals("A lot!"));
       expect(mock.methodWithNormalArgs(101), equals("A lot!"));
+    });
+    test("should mock method with multiple named args and matchers", (){
+      when(mock.methodWithTwoNamedArgs(any, y: any)).thenReturn("x y");
+      when(mock.methodWithTwoNamedArgs(any, z: any)).thenReturn("x z");
+      expect(mock.methodWithTwoNamedArgs(42), isNull);
+      expect(mock.methodWithTwoNamedArgs(42, y:18), equals("x y"));
+      expect(mock.methodWithTwoNamedArgs(42, z:17), equals("x z"));
+      expect(mock.methodWithTwoNamedArgs(42, y:18, z:17), isNull);
+      when(mock.methodWithTwoNamedArgs(any, y: any, z: any))
+          .thenReturn("x y z");
+      expect(mock.methodWithTwoNamedArgs(42, y:18, z:17), equals("x y z"));
     });
     test("should mock method with mix of argument matchers and real things",
         () {


### PR DESCRIPTION
…sure

that the match will fail if the specified named arguments in the actual
invocation differ from the mocked invocation.

Updated tests to include test cases for the above change.

Changed the top-level "any" and "captureAny" _ArgMatchers to use the
"anything" Matcher from test, rather than using null and having to test
for a null Matcher in isMatchingArg().