### PR TITLE
Add docs for the argument matchers, and thenAnswer()

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,7 @@ class Cat {
 }
 
 //Mock class
-class MockCat extends Mock implements Cat{
-  //this tells Dart analyzer you meant not to implement all methods, and not to hint/warn that methods are missing 
-  noSuchMethod(i) => super.noSuchMethod(i);
-}
+class MockCat extends Mock implements Cat {}
 
 //mock creation
 var cat = new MockCat();
@@ -59,6 +56,11 @@ expect(cat.lives, 9);
 //you can stub a method to throw
 when(cat.lives).thenThrow(new RangeError('Boo'));
 expect(() => cat.lives, throwsRangeError);
+//we can calculate a response at call time:
+var responses = ["Purr", "Meow"];
+when(cat.sound()).thenAnswer(() => responses.removeAt(0));
+expect(cat.sound(), "Purr");
+expect(cat.sound(), "Meow");
 ```
 
 By default, for all methods that return value, mock returns null.

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -437,11 +437,22 @@ class _ArgMatcher {
   _ArgMatcher(this._matcher, this._capture);
 }
 
+/// An argument matcher that matches any argument passed in "this" position.
 get any => new _ArgMatcher(anything, false);
+
+/// An argument matcher that matches any argument passed in "this" position, and
+/// captures the argument for later access with `captured`.
 get captureAny => new _ArgMatcher(anything, true);
-captureThat(Matcher matcher) => new _ArgMatcher(matcher, true);
+
+/// An argument matcher that matches an argument that matches [matcher].
 argThat(Matcher matcher) => new _ArgMatcher(matcher, false);
 
+/// An argument matcher that matches an argument that matches [matcher], and
+/// captures the argument for later access with `captured`.
+captureThat(Matcher matcher) => new _ArgMatcher(matcher, true);
+
+/// A Strong-mode safe argument matcher that wraps other argument matchers.
+/// See the README for a full explanation.
 /*=T*/ typed/*<T>*/(_ArgMatcher matcher, {String named}) {
   if (named == null) {
     _typedArgs.add(matcher);


### PR DESCRIPTION
Fixes #30, #32