### PR TITLE
Tighten public API + cleanup 

### DIFF
--- a/lib/mockito.dart
+++ b/lib/mockito.dart
@@ -1,2 +1,2 @@
-export 'src/mock.dart' hide setDefaultResponse;
-export 'src/spy.dart';
+export 'mockito_no_mirrors.dart';
+export 'src/spy.dart' show spy;

--- a/lib/mockito_no_mirrors.dart
+++ b/lib/mockito_no_mirrors.dart
@@ -1,1 +1,28 @@
-export 'src/mock.dart' hide setDefaultResponse;
+export 'src/mock.dart'
+    show
+        Mock,
+        named,
+
+        // -- setting behaviour
+        when,
+        any,
+        argThat,
+        captureAny,
+        captureThat,
+        typed,
+        Answering,
+        Expectation,
+        PostExpectation,
+
+        // -- verification
+        verify,
+        verifyInOrder,
+        verifyNever,
+        verifyNoMoreInteractions,
+        verifyZeroInteractions,
+        VerificationResult,
+
+        // -- misc
+        clearInteractions,
+        reset,
+        logInvocations;

--- a/lib/mockito_no_mirrors.dart
+++ b/lib/mockito_no_mirrors.dart
@@ -21,6 +21,7 @@ export 'src/mock.dart'
         verifyNoMoreInteractions,
         verifyZeroInteractions,
         VerificationResult,
+        Verification,
 
         // -- misc
         clearInteractions,

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -526,15 +526,15 @@ class VerificationResult {
 
 typedef dynamic Answering(Invocation realInvocation);
 
-typedef VerificationResult _Verification(matchingInvocations);
+typedef VerificationResult Verification(matchingInvocations);
 
 typedef void _InOrderVerification(List<dynamic> recordedInvocations);
 
-_Verification get verifyNever => _makeVerify(true);
+Verification get verifyNever => _makeVerify(true);
 
-_Verification get verify => _makeVerify(false);
+Verification get verify => _makeVerify(false);
 
-_Verification _makeVerify(bool never) {
+Verification _makeVerify(bool never) {
   if (_verifyCalls.isNotEmpty) {
     throw new StateError(_verifyCalls.join());
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mockito
-version: 1.0.1+2
+version: 2.0.0-dev
 authors:
   - Dmitriy Fibulwinter <fibulwinter@gmail.com>
   - Ted Sander <tsander@google.com>

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -1,5 +1,7 @@
 import 'package:test/test.dart';
-import 'package:mockito/mockito.dart';
+
+import 'package:mockito/src/mock.dart';
+import 'package:mockito/src/spy.dart';
 
 class RealClass {
   String methodWithoutArgs() => "Real";


### PR DESCRIPTION
Explicitly expose public methods in order not to leak internals and re-expose `mockito_no_mirrors.dart` from `mockito.dart` to ensure consistency.

Removes `CannedResponse`,  `InOrderVerification`, `Verification`, `RealCall`, `resetMockitoState` from the public API since these are only meant to be used internally by Mockito.

+ simplify `toString` logic in `RealCall`,
+ have `verifyInOrder` take a `List` since taking a single argument would be an invalid usage,
+ other minor adjustments and `dartfmt`