### PR TITLE
Move all mirrors-based API to mirrors.dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 2.0.0-dev
 
-* Deprecated usage of `spy` and any `dart:mirrors` based API. Users may
-  import as `package:mockito/deprecated.dart` until the 2.0.0 final
-  release.
+* Remove export of `spy` and any `dart:mirrors` based API from
+  `mockito.dart`. Users may import as `package:mockito/mirrors.dart`
+  going forward.
 * Deprecated `mockito_no_mirrors.dart`; replace with `mockito.dart`.
 
 ## 1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.0-dev
+
+* Deprecated usage of `spy` and any `dart:mirrors` based API. Users may
+  import as `package:mockito/deprecated.dart` until the 2.0.0 final
+  release.
+* Deprecated `mockito_no_mirrors.dart`; replace with `mockito.dart`.
+
 ## 1.0.1
 
 * Add a new `thenThrow` method to the API.

--- a/lib/deprecated.dart
+++ b/lib/deprecated.dart
@@ -1,0 +1,5 @@
+@Deprecated('Using spy() is deprecated as we drop dart:mirrors usage')
+library mockito.deprecated;
+
+export 'mockito.dart';
+export 'src/spy.dart' show spy;

--- a/lib/deprecated.dart
+++ b/lib/deprecated.dart
@@ -1,5 +1,0 @@
-@Deprecated('Using spy() is deprecated as we drop dart:mirrors usage')
-library mockito.deprecated;
-
-export 'mockito.dart';
-export 'src/spy.dart' show spy;

--- a/lib/mirrors.dart
+++ b/lib/mirrors.dart
@@ -1,0 +1,2 @@
+export 'mockito.dart';
+export 'src/spy.dart' show spy;

--- a/lib/mockito.dart
+++ b/lib/mockito.dart
@@ -1,2 +1,29 @@
-export 'mockito_no_mirrors.dart';
-export 'src/spy.dart' show spy;
+export 'src/mock.dart'
+    show
+    Mock,
+    named,
+
+    // -- setting behaviour
+    when,
+    any,
+    argThat,
+    captureAny,
+    captureThat,
+    typed,
+    Answering,
+    Expectation,
+    PostExpectation,
+
+    // -- verification
+    verify,
+    verifyInOrder,
+    verifyNever,
+    verifyNoMoreInteractions,
+    verifyZeroInteractions,
+    VerificationResult,
+    Verification,
+
+    // -- misc
+    clearInteractions,
+    reset,
+    logInvocations;

--- a/lib/mockito_no_mirrors.dart
+++ b/lib/mockito_no_mirrors.dart
@@ -1,29 +1,4 @@
-export 'src/mock.dart'
-    show
-        Mock,
-        named,
+@Deprecated('Import "mockito.dart" instead.')
+library mockito.mockito_no_mirrors;
 
-        // -- setting behaviour
-        when,
-        any,
-        argThat,
-        captureAny,
-        captureThat,
-        typed,
-        Answering,
-        Expectation,
-        PostExpectation,
-
-        // -- verification
-        verify,
-        verifyInOrder,
-        verifyNever,
-        verifyNoMoreInteractions,
-        verifyZeroInteractions,
-        VerificationResult,
-        Verification,
-
-        // -- misc
-        clearInteractions,
-        reset,
-        logInvocations;
+export 'mockito.dart';

--- a/lib/mockito_no_mirrors.dart
+++ b/lib/mockito_no_mirrors.dart
@@ -1,4 +1,4 @@
-@Deprecated('Import "mockito.dart" instead.')
+@Deprecated('Import "package:mockito/mockito.dart" instead.')
 library mockito.mockito_no_mirrors;
 
 export 'mockito.dart';

--- a/lib/src/mock.dart
+++ b/lib/src/mock.dart
@@ -1,6 +1,5 @@
 // Warning: Do not import dart:mirrors in this library, as it's exported via
-// lib/mockito_no_mirrors.dart, which is used for Dart AOT projects such as
-// Flutter.
+// lib/mockito.dart, which is used for Dart AOT projects such as Flutter.
 
 import 'package:meta/meta.dart';
 import 'package:test/test.dart';

--- a/lib/src/spy.dart
+++ b/lib/src/spy.dart
@@ -1,25 +1,17 @@
 // This file is intentionally separated from 'mock.dart' in order to avoid
-// bringing in the mirrors dependency into mockito_no_mirrors.dart.
+// bringing in the mirrors dependency into mockito.dart.
 import 'dart:mirrors';
 
-import 'mock.dart' show CannedResponse, setDefaultResponse;
+import 'mock.dart' show CannedResponse, Mock, setDefaultResponse;
 
-@Deprecated(
-  'Mockito is dropping support for spy(). Instead it is recommended to come '
-  'up with a code-generation technique or just hand-coding a Stub object that '
-  'forwards to a delegate. For example:\n\n'
-  'class SpyAnimal implements Animal {\n'
-  '  final Animal _delegate;\n'
-  '  FakeAnimal(this._delegate);\n'
-  '\n'
-  '  @override\n'
-  '  void eat() {\n'
-  '    _delegate.eat();\n'
-  '  }\n'
-  '}'
-)
-dynamic spy(dynamic mock, dynamic spiedObject) {
-  var mirror = reflect(spiedObject);
+/// Sets the default response of [mock] to be delegated to [spyOn].
+///
+/// __Example use__:
+///     var mockAnimal = new MockAnimal();
+///     var realAnimal = new RealAnimal();
+///     spy(mockAnimal, realAnimal);
+/*=E*/ spy/*<E>*/(Mock mock, Object /*=E*/ spyOn) {
+  var mirror = reflect(spyOn);
   setDefaultResponse(
       mock,
       () => new CannedResponse(null,

--- a/lib/src/spy.dart
+++ b/lib/src/spy.dart
@@ -4,6 +4,20 @@ import 'dart:mirrors';
 
 import 'mock.dart' show CannedResponse, setDefaultResponse;
 
+@Deprecated(
+  'Mockito is dropping support for spy(). Instead it is recommended to come '
+  'up with a code-generation technique or just hand-coding a Stub object that '
+  'forwards to a delegate. For example:\n\n'
+  'class SpyAnimal implements Animal {\n'
+  '  final Animal _delegate;\n'
+  '  FakeAnimal(this._delegate);\n'
+  '\n'
+  '  @override\n'
+  '  void eat() {\n'
+  '    _delegate.eat();\n'
+  '  }\n'
+  '}'
+)
 dynamic spy(dynamic mock, dynamic spiedObject) {
   var mirror = reflect(spiedObject);
   setDefaultResponse(

--- a/test/invocation_matcher_test.dart
+++ b/test/invocation_matcher_test.dart
@@ -54,7 +54,7 @@ void main() {
       var call2 = stub.value;
       stub.value = true;
       var call3 = Stub.lastInvocation;
-      shouldPass(call1, isInvocation(call2));
+      shouldPass(call1, isInvocation(call2 as Invocation));
       shouldFail(
         call1,
         isInvocation(call3),

--- a/test/mockito_test.dart
+++ b/test/mockito_test.dart
@@ -1,7 +1,6 @@
+import 'package:mockito/mockito.dart';
+import 'package:mockito/src/mock.dart' show resetMockitoState;
 import 'package:test/test.dart';
-
-import 'package:mockito/src/mock.dart';
-import 'package:mockito/src/spy.dart';
 
 class RealClass {
   String methodWithoutArgs() => "Real";
@@ -67,24 +66,6 @@ void main() {
     // In some of the tests that expect an Error to be thrown, Mockito's
     // global state can become invalid. Reset it.
     resetMockitoState();
-  });
-
-  group("spy", () {
-    setUp(() {
-      mock = spy(new MockedClass(), new RealClass());
-    });
-
-    test("should delegate to real object by default", () {
-      expect(mock.methodWithoutArgs(), 'Real');
-    });
-    test("should record interactions delegated to real object", () {
-      mock.methodWithoutArgs();
-      verify(mock.methodWithoutArgs());
-    });
-    test("should behave as mock when expectation are set", () {
-      when(mock.methodWithoutArgs()).thenReturn('Spied');
-      expect(mock.methodWithoutArgs(), 'Spied');
-    });
   });
 
   group("mixin support", () {

--- a/test/spy_test.dart
+++ b/test/spy_test.dart
@@ -1,5 +1,5 @@
 import 'package:mockito/src/mock.dart' show resetMockitoState;
-import 'package:mockito/deprecated.dart';
+import 'package:mockito/mirrors.dart';
 import 'package:test/test.dart';
 
 import 'mockito_test.dart' show MockedClass, RealClass;
@@ -19,7 +19,7 @@ void main() {
 
   group("spy", () {
     setUp(() {
-      mock = spy(new MockedClass(), new RealClass());
+      mock = spy/*<RealClass>*/(new MockedClass(), new RealClass());
     });
 
     test("should delegate to real object by default", () {

--- a/test/spy_test.dart
+++ b/test/spy_test.dart
@@ -1,0 +1,37 @@
+import 'package:mockito/src/mock.dart' show resetMockitoState;
+import 'package:mockito/deprecated.dart';
+import 'package:test/test.dart';
+
+import 'mockito_test.dart' show MockedClass, RealClass;
+
+void main() {
+  RealClass mock;
+
+  setUp(() {
+    mock = new MockedClass();
+  });
+
+  tearDown(() {
+    // In some of the tests that expect an Error to be thrown, Mockito's
+    // global state can become invalid. Reset it.
+    resetMockitoState();
+  });
+
+  group("spy", () {
+    setUp(() {
+      mock = spy(new MockedClass(), new RealClass());
+    });
+
+    test("should delegate to real object by default", () {
+      expect(mock.methodWithoutArgs(), 'Real');
+    });
+    test("should record interactions delegated to real object", () {
+      mock.methodWithoutArgs();
+      verify(mock.methodWithoutArgs());
+    });
+    test("should behave as mock when expectation are set", () {
+      when(mock.methodWithoutArgs()).thenReturn('Spied');
+      expect(mock.methodWithoutArgs(), 'Spied');
+    });
+  });
+}


### PR DESCRIPTION
Updated `CHANGELOG.md`, and removed need to import `mockito_no_mirrors.dart` for Flutter.

# Breaking Changes

* To use `spy()`, you must import `package:mockito/mirrors.dart`.
